### PR TITLE
Internationalize application and add Japanese translation

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,9 +2,9 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <meta http-equiv="content-type" content="text/html;charset=UTF-8" />
-  <meta name="description" content="Peritor Webistrano - Capristrano Deployment the easy way" />
-  <meta name="keywords" content="rubyonrails ruby rails capistrano deployment" />
-  <title>Peritor Webistrano - <%=h @page_title %></title>
+  <meta name="description" content="<%= t('layouts.application.description') %>" />
+  <meta name="keywords" content="<%= t('layouts.application.keywords') %>" />
+  <title><%= t('layouts.application.title', :page_title => h(@page_title)) %></title>
   <link rel="shortcut icon" href="/favicon.ico"></link>
   <%= javascript_include_tag :defaults %>
   <%= stylesheet_link_tag 'application' %>
@@ -14,7 +14,7 @@
 <body>
   <div id="app_top">
     <div id="header">
-      <div id="header_claim">Capistrano deployment the easy way</div>
+      <div id="header_claim"><%= t('layouts.application.claim') %></div>
       <a href="<%= home_path %>"><%= image_tag('peritor_theme/webistrano_logo.gif', :border => '0')%></a>
     </div>
     <div id="main_content">
@@ -50,10 +50,10 @@
   <div id="footer">
     <div id="footer_logged">
       <% if logged_in? %>
-       Logged in as <%= link_to h(current_user.login), user_path(current_user) %> | <%= link_to 'Logout', logout_path %> 
+       <%= t('layouts.application.logged_in_as') %> <%= link_to h(current_user.login), user_path(current_user) %> | <%= link_to t('layouts.application.logout'), logout_path %>
       <% end %>
     </div>
-    Copyright &copy; 2007, 2008, 2009 | Version <%=h WEBISTRANO_VERSION %> | <a href="http://labs.peritor.com/webistrano" target="_blank">http://labs.peritor.com/webistrano</a>
+    <%= raw t('layouts.application.copyright', :version => h(WEBISTRANO_VERSION)) %>
   </div>
 </body>
 

--- a/app/views/projects/dashboard.html.erb
+++ b/app/views/projects/dashboard.html.erb
@@ -1,31 +1,30 @@
 <fieldset class="fieldset">
-  <legend>Introduction and help</legend>
+  <legend><%= t('projects.dashboard.introduction_legend') %></legend>
   <div style="float: right; padding: 10px 5px 5px 5px;">
     <a href="http://labs.peritor.com/webistrano" target="_blank"><%= image_tag('peritor_theme/webistrano_screenshot.png', :border => '0', :width => '200', :height => '151')%></a>
   </div>
   <div style="padding-top: 5px;">
-   Welcome to Webistrano. Your first steps should be to create a project with a stage.
-   This stage can then be deployed once you made at least one host known to Webistrano.
+   <%= t('projects.dashboard.introduction_text') %>
    <br /><br />
-   For help and more documentation, see
+   <%= t('projects.dashboard.help_text') %>
    <br />
    <ul>
-     <li><a href="http://labs.peritor.com/webistrano/">Wiki</a></li>
-     <li><a href="http://labs.peritor.com/webistrano/wiki/ConfigurationParameter">Configuration Parameter</a></li>
-     <li><a href="http://labs.peritor.com/webistrano/wiki/FAQ">FAQ</a></li>
+     <li><a href="http://labs.peritor.com/webistrano/"><%= t('projects.dashboard.wiki') %></a></li>
+     <li><a href="http://labs.peritor.com/webistrano/wiki/ConfigurationParameter"><%= t('projects.dashboard.configuration_parameter') %></a></li>
+     <li><a href="http://labs.peritor.com/webistrano/wiki/FAQ"><%= t('projects.dashboard.faq') %></a></li>
    </ul>
    <br />
-   Webistrano is Open Source. Paid support is available by <a href="http://www.peritor.com">Peritor Consulting</a>.
+   <%= raw t('projects.dashboard.support_text', :peritor_consulting_link => link_to('Peritor Consulting', 'http://www.peritor.com')) %>
   </div>
 </fieldset>
 
 <br />
 
 <fieldset class="fieldset">
-  <legend>Recent deployments</legend>
+  <legend><%= t('projects.dashboard.recent_deployments_legend') %></legend>
   <% if @deployments.empty? %>
     <br/>
-      No recent deployments.
+      <%= t('projects.dashboard.no_recent_deployments') %>
     <br/>
   <% else %>
     <% @deployments.each do |deployment| %>
@@ -37,6 +36,6 @@
 <br />
 
 <% content_for(:page_title) do %>
-  <% @page_title = "Welcome to Webistrano" %>
-  <h2>Welcome to Webistrano</h2>
+  <% @page_title = t('projects.dashboard.title') %>
+  <h2><%= t('projects.dashboard.title') %></h2>
 <% end %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,25 +1,25 @@
 <% form_tag sessions_path do -%>
 
   <fieldset class="fieldset">
-    <legend>Webistrano login</legend>
+    <legend><%= t('sessions.new.legend') %></legend>
     <div style="float: right; padding: 20px;">
       <%= image_tag('peritor_theme/webistrano_logo_large.png', :border => '0', :width => '400', :height => '130')%>
     </div>
     <div>
-      <p><label for="login">Login</label><br/>
+      <p><label for="login"><%= t('sessions.new.login') %></label><br/>
       <%= text_field_tag 'login' %></p>
-      <p><label for="password">Password</label><br/>
+      <p><label for="password"><%= t('sessions.new.password') %></label><br/>
       <%= password_field_tag 'password' %></p>
       <p><%= check_box_tag 'remember_me', '1', {}, :class => 'noframe' %>
-      <label for="remember_me">Remember me</label></p>
+      <label for="remember_me"><%= t('sessions.new.remember_me') %></label></p>
       <p>
-      <%= submit_tag 'Log in' %>
+      <%= submit_tag t('sessions.new.log_in') %>
       </p>
     </div>
   </fieldset>
 <% end -%>
 
 <% content_for(:page_title) do %>
-  <% @page_title = "Login" %>
-  <h2 style="color: #A40008; ">Welcome to Webistrano</h2>
+  <% @page_title = t('sessions.new.title') %>
+  <h2 style="color: #A40008; "><%= t('sessions.new.welcome') %></h2>
 <% end %>

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -14,6 +14,36 @@ require File.join(File.dirname(__FILE__), 'boot')
 require "#{RAILS_ROOT}/config/webistrano_config"
 
 Rails::Initializer.run do |config|
+  # Settings in config/environments/* take precedence over those specified here.
+  # Application configuration should go into files in config/initializers
+  # -- all .rb files in that directory are automatically loaded.
+
+  # Add additional load paths for your own custom dirs
+  # config.load_paths += %W( #{RAILS_ROOT}/extras )
+
+  # Specify gems that this application depends on and have them installed with rake gems:install
+  # config.gem "hpricot", :version => '0.6', :source => "http://code.whytheluckystiff.net"
+  # config.gem "sqlite3-ruby", :lib => "sqlite3"
+  # config.gem "aws-s3", :lib => "aws/s3"
+
+  # Only load the plugins named here, in the order given (default is alphabetical).
+  # :all can be used as a placeholder for all plugins not explicitly named
+  # config.plugins = [ :exception_notification, :ssl_requirement, :all ]
+
+  # Skip frameworks you're not going to use. To use Rails without a database,
+  # you must remove the Active Record framework.
+  # config.frameworks -= [ :active_record, :active_resource, :action_mailer ]
+
+  # Activate observers that should always be running
+  # config.active_record.observers = :cacher, :garbage_collector, :forum_observer
+
+  # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
+  # Run "rake -D time" for a list of tasks for finding time zone names.
+  config.time_zone = 'UTC'
+
+  # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
+  config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '*.{rb,yml}').to_s]
+  config.i18n.default_locale = :ja
 
   # Your secret key for verifying cookie session data integrity.
   # If you change this key, all old sessions will become invalid!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,31 @@
+en:
+  layouts:
+    application:
+      title: "Peritor Webistrano - %{page_title}"
+      description: "Peritor Webistrano - Capistrano Deployment the easy way"
+      keywords: "rubyonrails ruby rails capistrano deployment"
+      claim: "Capistrano deployment the easy way"
+      logged_in_as: "Logged in as"
+      logout: "Logout"
+      copyright: "Copyright &copy; 2007, 2008, 2009 | Version %{version} | <a href='http://labs.peritor.com/webistrano' target='_blank'>http://labs.peritor.com/webistrano</a>"
+  sessions:
+    new:
+      title: "Login"
+      welcome: "Welcome to Webistrano"
+      login: "Login"
+      password: "Password"
+      remember_me: "Remember me"
+      log_in: "Log in"
+      legend: "Webistrano login"
+  projects:
+    dashboard:
+      title: "Welcome to Webistrano"
+      introduction_legend: "Introduction and help"
+      introduction_text: "Welcome to Webistrano. Your first steps should be to create a project with a stage. This stage can then be deployed once you made at least one host known to Webistrano."
+      help_text: "For help and more documentation, see"
+      wiki: "Wiki"
+      configuration_parameter: "Configuration Parameter"
+      faq: "FAQ"
+      support_text: "Webistrano is Open Source. Paid support is available by %{peritor_consulting_link}."
+      recent_deployments_legend: "Recent deployments"
+      no_recent_deployments: "No recent deployments."

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,31 @@
+ja:
+  layouts:
+    application:
+      title: "Peritor Webistrano - %{page_title}"
+      description: "Peritor Webistrano - Capistranoデプロイを簡単に"
+      keywords: "rubyonrails ruby rails capistrano deployment"
+      claim: "Capistranoデプロイを簡単に"
+      logged_in_as: "でログイン中"
+      logout: "ログアウト"
+      copyright: "Copyright &copy; 2007, 2008, 2009 | Version %{version} | <a href='http://labs.peritor.com/webistrano' target='_blank'>http://labs.peritor.com/webistrano</a>"
+  sessions:
+    new:
+      title: "ログイン"
+      welcome: "Webistranoへようこそ"
+      login: "ログイン"
+      password: "パスワード"
+      remember_me: "ログイン情報を記憶する"
+      log_in: "ログイン"
+      legend: "Webistranoログイン"
+  projects:
+    dashboard:
+      title: "Webistranoへようこそ"
+      introduction_legend: "はじめにとヘルプ"
+      introduction_text: "Webistranoへようこそ。最初のステップは、ステージを持つプロジェクトを作成することです。このステージは、Webistranoに少なくとも1つのホストを知らせた後でデプロイできます。"
+      help_text: "ヘルプと詳細なドキュメントについては、以下を参照してください。"
+      wiki: "Wiki"
+      configuration_parameter: "設定パラメータ"
+      faq: "FAQ"
+      support_text: "Webistranoはオープンソースです。有料サポートは%{peritor_consulting_link}によって利用可能です。"
+      recent_deployments_legend: "最近のデプロイ"
+      no_recent_deployments: "最近のデプロイはありません。"


### PR DESCRIPTION
This change internationalizes the application and adds Japanese as the default language.

The following changes were made:
- Added i18n configuration to `config/environment.rb`.
- Created `config/locales` directory with `en.yml` and `ja.yml` files.
- Set the default locale to `:ja`.
- Internationalized the application layout, login page, and dashboard.